### PR TITLE
chore: improve coverage workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,33 +4,17 @@ on:
   push:
     branches: ['main']
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: 'pages'
-  cancel-in-progress: true
-
 jobs:
-  test:
-    strategy:
-      matrix:
-        node-version:
-          - 18.x
-        os:
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+  build:
+    name: 'Run Coverage Tests'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -41,14 +25,36 @@ jobs:
       - name: Run Coverage Tests
         run: yarn coverage
 
-      - name: Setup GitHub Pages
-        uses: actions/configure-pages@v2
-
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: 'coverage/lcov-report'
 
+  deploy:
+    name: 'Deploy Coverage Report'
+    needs: build
+
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    # Allow one concurrent deployment
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: github-pages
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v2
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
# Description

This PR separates the coverage execution script into another workflow job. Note: This PR isn't for supporting deploy coverage report base on commit.