### PR TITLE
chore: move `_beforeProposalExecuted` callback after whitelist checks

### DIFF
--- a/contracts/InterchainProposalExecutor.sol
+++ b/contracts/InterchainProposalExecutor.sol
@@ -42,8 +42,6 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
         string calldata sourceAddress,
         bytes calldata payload
     ) internal override {
-        _beforeProposalExecuted(sourceChain, sourceAddress, payload);
-
         // Check that the source address is whitelisted
         if (!whitelistedSenders[sourceChain][sourceAddress]) {
             revert NotWhitelistedSourceAddress();
@@ -59,6 +57,8 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
         if (!whitelistedCallers[sourceChain][sourceCaller]) {
             revert NotWhitelistedCaller();
         }
+
+        _beforeProposalExecuted(sourceChain, sourceAddress, sourceCaller, calls);
 
         // Execute the proposal with the given arguments
         _executeProposal(calls);
@@ -125,15 +125,14 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
      * This function can be used to handle the payload before the proposal is executed.
      * @param sourceChain The source chain from where the proposal was sent.
      * @param sourceAddress The source address that sent the proposal. The source address should be the `InterchainProposalSender` contract address at the source chain.
-     * @param payload The payload. It is ABI encoded of the caller and calls.
-     * Where:
-     * - `caller` is the address that calls the `InterchainProposalSender` at the source chain.
-     * - `calls` is the array of `InterchainCalls.Call` to execute. Each call contains the target, value, calldata.
+     * @param caller The caller that calls the `InterchainProposalSender` at the source chain.
+     * @param calls The array of `InterchainCalls.Call` to execute. Each call contains the target, value, and callData.
      */
     function _beforeProposalExecuted(
         string calldata sourceChain,
         string calldata sourceAddress,
-        bytes calldata payload
+        address caller,
+        InterchainCalls.Call[] memory calls
     ) internal virtual {
         // You can add your own logic here to handle the payload before the proposal is executed.
     }


### PR DESCRIPTION
# Description

This PR addresses `W1: _beforeProposalExecuted hook order` in the audit report