### PR TITLE
chore: change whitelisted caller type from `address` to `bytes`

### DIFF
--- a/contracts/InterchainProposalExecutor.sol
+++ b/contracts/InterchainProposalExecutor.sol
@@ -20,7 +20,7 @@ import { InterchainCalls } from './lib/InterchainCalls.sol';
  */
 contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecutable, Ownable {
     // Whitelisted proposal callers. The proposal caller is the contract that calls the `InterchainProposalSender` at the source chain.
-    mapping(string => mapping(address => bool)) public whitelistedCallers;
+    mapping(string => mapping(bytes => bool)) public whitelistedCallers;
 
     // Whitelisted proposal senders. The proposal sender is the `InterchainProposalSender` contract address at the source chain.
     mapping(string => mapping(string => bool)) public whitelistedSenders;
@@ -50,9 +50,9 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
         }
 
         // Decode the payload
-        (address sourceCaller, InterchainCalls.Call[] memory calls) = abi.decode(
+        (bytes memory sourceCaller, InterchainCalls.Call[] memory calls) = abi.decode(
             payload,
-            (address, InterchainCalls.Call[])
+            (bytes, InterchainCalls.Call[])
         );
 
         // Check that the caller is whitelisted
@@ -97,7 +97,7 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
      */
     function setWhitelistedProposalCaller(
         string calldata sourceChain,
-        address sourceCaller,
+        bytes memory sourceCaller,
         bool whitelisted
     ) external override onlyOwner {
         whitelistedCallers[sourceChain][sourceCaller] = whitelisted;
@@ -135,7 +135,7 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
     function _beforeProposalExecuted(
         string calldata sourceChain,
         string calldata sourceAddress,
-        address caller,
+        bytes memory caller,
         InterchainCalls.Call[] memory calls
     ) internal virtual {
         // You can add your own logic here to handle the payload before the proposal is executed.
@@ -152,7 +152,7 @@ contract InterchainProposalExecutor is IInterchainProposalExecutor, AxelarExecut
     function _onProposalExecuted(
         string calldata /* sourceChain */,
         string calldata /* sourceAddress */,
-        address /* caller */,
+        bytes memory /* caller */,
         bytes calldata payload
     ) internal virtual {
         // You can add your own logic here to handle the payload after the proposal is executed.

--- a/contracts/InterchainProposalSender.sol
+++ b/contracts/InterchainProposalSender.sol
@@ -90,7 +90,7 @@ contract InterchainProposalSender is IInterchainProposalSender {
     }
 
     function _sendProposal(InterchainCalls.InterchainCall memory interchainCall) internal {
-        bytes memory payload = abi.encode(msg.sender, interchainCall.calls);
+        bytes memory payload = abi.encode(abi.encodePacked(msg.sender), interchainCall.calls);
 
         if (interchainCall.gas > 0) {
             gasService.payNativeGasForContractCall{ value: interchainCall.gas }(

--- a/contracts/interfaces/IInterchainProposalExecutor.sol
+++ b/contracts/interfaces/IInterchainProposalExecutor.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 
 interface IInterchainProposalExecutor {
     // An event emitted when the proposal caller is whitelisted
-    event WhitelistedProposalCallerSet(string indexed sourceChain, address indexed sourceCaller, bool whitelisted);
+    event WhitelistedProposalCallerSet(string indexed sourceChain, bytes indexed sourceCaller, bool whitelisted);
 
     // An event emitted when the proposal sender is whitelisted
     event WhitelistedProposalSenderSet(string indexed sourceChain, string sourceSender, bool whitelisted);
@@ -39,5 +39,9 @@ interface IInterchainProposalExecutor {
      * @param sourceCaller The source interchain caller address
      * @param whitelisted The whitelisted status
      */
-    function setWhitelistedProposalCaller(string calldata sourceChain, address sourceCaller, bool whitelisted) external;
+    function setWhitelistedProposalCaller(
+        string calldata sourceChain,
+        bytes memory sourceCaller,
+        bool whitelisted
+    ) external;
 }

--- a/test/e2e/e2e-multi-dest-chains.test.ts
+++ b/test/e2e/e2e-multi-dest-chains.test.ts
@@ -153,7 +153,7 @@ describe('Interchain Governance Executor for Multiple Destination Chains [ @skip
     // Wait for the proposal to be executed on the destination chain
     // Encode the payload for the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
-      ['address', '(address target, uint256 value, bytes callData)[]'],
+      ['bytes', '(address target, uint256 value, bytes callData)[]'],
       [timelock.address, xCalls[0].calls],
     );
 

--- a/test/e2e/e2e-single-dest-chain.test.ts
+++ b/test/e2e/e2e-single-dest-chain.test.ts
@@ -138,7 +138,7 @@ describe('Interchain Governance Executor For Single Destination Chain [ @skip-on
     // Wait for the proposal to be executed on the destination chain
     // Encode the payload for the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
-      ['address', '(address target, uint256 value, bytes callData)[]'],
+      ['bytes', '(address target, uint256 value, bytes callData)[]'],
       [timelock.address, calls],
     );
 
@@ -220,7 +220,7 @@ describe('Interchain Governance Executor For Single Destination Chain [ @skip-on
 
     // Wait for the proposal to be executed on the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
-      ['address', '(address target, uint256 value, bytes callData)[]'],
+      ['bytes', '(address target, uint256 value, bytes callData)[]'],
       [timelock.address, calls],
     );
     await waitProposalExecuted(
@@ -304,7 +304,7 @@ describe('Interchain Governance Executor For Single Destination Chain [ @skip-on
     // Wait for the proposal to be executed on the destination chain
     // Encode the payload for the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
-      ['address', '(address target, uint256 value, bytes callData)[]'],
+      ['bytes', '(address target, uint256 value, bytes callData)[]'],
       [timelock.address, calls],
     );
 
@@ -386,7 +386,7 @@ describe('Interchain Governance Executor For Single Destination Chain [ @skip-on
 
     // Wait for the proposal to be executed on the destination chain
     const payload = ethers.utils.defaultAbiCoder.encode(
-      ['address', '(address target, uint256 value, bytes callData)[]'],
+      ['bytes', '(address target, uint256 value, bytes callData)[]'],
       [deployer.address, calls],
     );
     await waitProposalExecuted(

--- a/test/e2e/utils/wait.ts
+++ b/test/e2e/utils/wait.ts
@@ -12,7 +12,7 @@ export const waitProposalExecuted = (
       executorContract.filters.ProposalExecuted(
         ethers.utils.keccak256(
           ethers.utils.defaultAbiCoder.encode(
-            ['string', 'string', 'address', 'bytes'],
+            ['string', 'string', 'bytes', 'bytes'],
             [sourceChain, sourceAddress, caller, payload],
           ),
         ),

--- a/test/unit/interchain-proposal-executor.test.ts
+++ b/test/unit/interchain-proposal-executor.test.ts
@@ -63,6 +63,7 @@ describe('InterchainProposalExecutor', function () {
         signerAddress,
         true,
       );
+
       await executor.setWhitelistedProposalSender(
         chains.ethereum,
         signerAddress,
@@ -81,7 +82,7 @@ describe('InterchainProposalExecutor', function () {
       ];
 
       const payload = ethers.utils.defaultAbiCoder.encode(
-        ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+        ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
         [signerAddress, calls],
       );
 
@@ -93,7 +94,7 @@ describe('InterchainProposalExecutor', function () {
         .withArgs(
           ethers.utils.keccak256(
             ethers.utils.defaultAbiCoder.encode(
-              ['string', 'string', 'address', 'bytes'],
+              ['string', 'string', 'bytes', 'bytes'],
               [chains.ethereum, signerAddress, signerAddress, payload],
             ),
           ),
@@ -131,7 +132,7 @@ describe('InterchainProposalExecutor', function () {
         ];
 
         const payload = ethers.utils.defaultAbiCoder.encode(
-          ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+          ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
           [signerAddress, calls],
         );
 
@@ -161,7 +162,7 @@ describe('InterchainProposalExecutor', function () {
       ];
 
       const payload = ethers.utils.defaultAbiCoder.encode(
-        ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+        ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
         [signerAddress, calls],
       );
 
@@ -194,7 +195,7 @@ describe('InterchainProposalExecutor', function () {
       ];
 
       const payload = ethers.utils.defaultAbiCoder.encode(
-        ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+        ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
         [signerAddress, calls],
       );
 

--- a/test/unit/interchain-proposal-sender.test.ts
+++ b/test/unit/interchain-proposal-sender.test.ts
@@ -97,7 +97,7 @@ describe('InterchainProposalSender', function () {
         );
 
       const payload = ethers.utils.defaultAbiCoder.encode(
-        ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+        ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
         [signerAddress, calls],
       );
 
@@ -200,7 +200,7 @@ describe('InterchainProposalSender', function () {
       const broadcast = () => sender.sendProposals(xCalls, { value: 2 });
 
       const payload = ethers.utils.defaultAbiCoder.encode(
-        ['address', 'tuple(address target, uint256 value, bytes callData)[]'],
+        ['bytes', 'tuple(address target, uint256 value, bytes callData)[]'],
         [signerAddress, calls],
       );
 


### PR DESCRIPTION
# Description

- Changed `whitelistedCaller` type from `address` to `bytes` in **InterchainProposalExecutor.sol**
- Changed encoding type for caller from `address` to `bytes` in **InterchainProposalSender.sol**